### PR TITLE
4 id and to map

### DIFF
--- a/lib/params/schema.ex
+++ b/lib/params/schema.ex
@@ -60,7 +60,7 @@ defmodule Params.Schema do
     quote do
       use Ecto.Schema
       import Ecto.Changeset
-      @primary_key {:id, :binary_id, autogenerate: false}
+      @primary_key {:_id, :binary_id, autogenerate: false}
     end
   end
 

--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -16,7 +16,7 @@ defmodule ParamsTest do
   test "module has schema types" do
     assert %{age: :integer,
              name: :string,
-             id: :binary_id} ==
+             _id: :binary_id} ==
       PetParams.__changeset__
   end
 
@@ -25,7 +25,7 @@ defmodule ParamsTest do
   end
 
   test "defaults to all optional fields" do
-    assert [:age, :id, :name] == Params.optional PetParams
+    assert [:_id, :age, :name] == Params.optional PetParams
   end
 
   test "from returns a changeset" do
@@ -162,8 +162,9 @@ defmodule ParamsTest do
 
   test "can obtain data from changeset" do
     m = Params.data kid(%{name: "hugo", age: "5"})
-    assert "hugo" = m.name
-    assert 5 = m.age
+    assert "hugo" == m.name
+    assert 5 == m.age
+    assert nil == m._id
   end
 
   defmodule SearchUser do

--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -89,14 +89,17 @@ defmodule ParamsTest do
   end
 
 
-  test "changes gets casted values" do
+  test "to_map gets map of struct except for _id" do
+    # This test fails because of a missing @schema
     params = %{
-      "origin" => %{
-        "latitude" => "12.2",
-      }
+      "latitude" => 12.2,
+      "longitude" => 13.3
     }
-    changes = Params.changes BusParams.from(params)
-    assert %{origin: %{latitude: 12.2}} = changes
+    result = params
+              |> LocationParams.from
+              |> Params.to_map
+
+    assert result == %{latitude: 12.2, longitude: 13.3}
   end
 
   defparams kitten %{
@@ -235,6 +238,12 @@ defmodule ParamsTest do
     assert m.foo == "FOO"
   end
 
+  test "gets default values with to_map" do
+    changeset = schema_options(%{})
+    map = Params.to_map(changeset)
+    assert map == %{foo: "FOO"}
+  end
+
   defparams default_nested %{
     foo: %{
       bar: :string,
@@ -259,4 +268,20 @@ defmodule ParamsTest do
     assert nil == m.foo
   end
 
+  test "to_map works on nested schemas with default values" do
+    changeset = default_nested(%{})
+    assert changeset.valid?
+    result = Params.to_map(changeset)
+
+    assert result == %{
+      foo: nil,
+      bat: %{
+        man: "BATMAN",
+        wo: %{
+          man: "BATWOMAN"
+        },
+        mo: nil
+      }
+    }
+  end
 end


### PR DESCRIPTION
Hi @vic 

I made the stuff we discussed in #4 , but only in ecto-2.x branch for now.

There is a test that is failing, which seems unrelated to these changes. See my comment in the test. You might be able to see what is wrong and if I'm doing anything I shouldn't in the test.

* Renamed schema primary key from `id` to `_id`
* Renamed `changes` to `to_map` and changed it to include all values of the struct except some special values (`__meta__`, `__struct__` and `_id`)