### PR TITLE
Fixed to_map for nested schemas

### DIFF
--- a/lib/params.ex
+++ b/lib/params.ex
@@ -188,6 +188,7 @@ defmodule Params do
       case {k, v} do
         {:__meta__, _} -> m
         {:_id, _} -> m
+        {k, %{__struct__: _} = struct} -> Map.put(m, k, struct |> Map.from_struct |> sanitize_map)
         {k, %{} = nested} -> Map.put(m, k, sanitize_map(nested))
         {k, v} -> Map.put(m, k, v)
       end

--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -267,8 +267,9 @@ defmodule ParamsTest do
     assert nil == m.foo
   end
 
-  test "to_map works on nested schemas with default values" do
-    changeset = default_nested(%{})
+  test "to_map works on nested schemas with default values and empty input" do
+    changeset = %{} |> default_nested
+
     assert changeset.valid?
     result = Params.to_map(changeset)
 
@@ -276,6 +277,29 @@ defmodule ParamsTest do
       foo: nil,
       bat: %{
         man: "BATMAN",
+        wo: %{
+          man: "BATWOMAN"
+        },
+        mo: nil
+      }
+    }
+  end
+
+  test "to_map works on nested schemas with default values" do
+    changeset = %{
+      bat: %{
+        man: "Bruce"
+      }
+    }
+    |> default_nested
+
+    assert changeset.valid?
+    result = Params.to_map(changeset)
+
+    assert result == %{
+      foo: nil,
+      bat: %{
+        man: "Bruce",
         wo: %{
           man: "BATWOMAN"
         },


### PR DESCRIPTION
Found a bug with nested schemas when params was actually submitted.

I'm not really sure why this bug is.

It seems that when creating changeset from empty params and the schema has nested default values, `data` will contain maps of the nested data. When actually using a filled params, `data` will use structs for the nested data.

This fixes it, but I'm unsure if I only fixed the symptom.