### PR TITLE
9 to map skip missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,6 @@ required fields by ending them with a `!`, of course
 the bang is removed from the field definition and is
 only used to mark which fields are required by default.
 
-The [Params.data](http://hexdocs.pm/params/Params.html#data/1)
-and [Params.changes](http://hexdocs.pm/params/Params.html#changes/1) can be useful
-for obtaining an struct or map from a changeset.
-
 You can also create a module and define
 your schema or custom changesets in it:
 
@@ -230,6 +226,29 @@ defmodule MyApp.UserController do
   end
 
 end
+```
+
+The [Params.data](http://hexdocs.pm/params/Params.html#data/1)
+and [Params.to_map](http://hexdocs.pm/params/Params.html#to_map/1) can be useful
+for obtaining a struct or map from a changeset.
+
+Note that `Params.data` and `Params.to_map` have different behaviour: `data`
+returns a struct which will include all valid params. `to_map` returns a map
+that only includes the submitted keys and keys with default values:
+
+```elixir
+defmodule UserUpdateParams do
+  use Params.Schema, %{
+    name: :string,
+    age: :integer,
+    auditlog: [field: :boolean, default: true]
+  }
+end
+
+changeset = UserUpdateParams.from(%{name: "John"})
+
+Params.data(changeset) # => %UserUpdateParams{name: "John", age: nil, auditlog: true}
+Params.to_map(changeset) # => %{name: "John", auditlog: true}
 ```
 
 ## API Documentation

--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -274,13 +274,11 @@ defmodule ParamsTest do
     result = Params.to_map(changeset)
 
     assert result == %{
-      foo: nil,
       bat: %{
         man: "BATMAN",
         wo: %{
           man: "BATWOMAN"
-        },
-        mo: nil
+        }
       }
     }
   end
@@ -297,13 +295,67 @@ defmodule ParamsTest do
     result = Params.to_map(changeset)
 
     assert result == %{
-      foo: nil,
       bat: %{
         man: "Bruce",
         wo: %{
           man: "BATWOMAN"
-        },
-        mo: nil
+        }
+      }
+    }
+  end
+
+  defmodule DefaultNested do
+    use Params.Schema, %{
+      a: :string,
+      b: :string,
+      c: [field: :string, default: "C"],
+      d: %{
+        e: :string,
+        f: :string,
+        g: [field: :string, default: "G"],
+      },
+      h: %{
+        i: :string,
+        j: :string,
+        k: [field: :string, default: "K"],
+      },
+      l: %{
+        m: :string
+      },
+      n: %{
+        o: %{
+          p: [field: :string, default: "P"]
+        }
+      }
+
+    }
+  end
+
+  test "to_map only returns submitted fields" do
+    result = %{
+      a: "A",
+      d: %{
+        e: "E",
+        g: "g"
+      }
+    }
+    |> DefaultNested.from
+    |> Params.to_map
+
+    assert result == %{
+      a: "A",
+      c: "C",
+      d: %{
+        e: "E",
+        g: "g"
+      },
+      h: %{
+        k: "K"
+      },
+      n: %{
+        o: %{
+          p: "P"
+        }
       }
     }
   end


### PR DESCRIPTION
`to_map` now only returns the submitted keys and keys with default values.

Closes #9 