### PR TITLE
Updating readme schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,15 +200,15 @@ defmodule UserSearch do
   use Params.Schema, %{name: :string, age: :integer}
 
   def child(ch, params) do
-    cast(ch, params, ~w(name age), ~w())
-    |> validate_inclusion(:age, 1..6)
+    Ecto.Changeset.cast(ch, params, ~w(name age), ~w())
+    |> Ecto.Changeset.validate_inclusion(:age, 1..6)
   end
 end
 
 defmodule MyApp.UserController do
 
   def index(conn, params) do
-    changeset = UserSearch.from(params, :child)
+    changeset = UserSearch.from(params, with: &UserSearch.child/2)
     if changeset.valid? do
       # age in 1..6
   end

--- a/README.md
+++ b/README.md
@@ -198,10 +198,11 @@ your schema or custom changesets in it:
 ```elixir
 defmodule UserSearch do
   use Params.Schema, %{name: :string, age: :integer}
+  import Ecto.Changeset, only: [cast: 4, validate_inclusion: 3]
 
   def child(ch, params) do
-    Ecto.Changeset.cast(ch, params, ~w(name age), ~w())
-    |> Ecto.Changeset.validate_inclusion(:age, 1..6)
+    cast(ch, params, ~w(name age), ~w())
+    |> validate_inclusion(:age, 1..6)
   end
 end
 


### PR DESCRIPTION
Using separate params schema module for custom ecto validations on api params.
Awesome product! Exactly what we needed. 👍 

I noticed two issues with the example in the readme for this.
- from function's second parameter is a list. So, the current example gives an function not found error because it doesn't pattern match because it is expecting a list.
- Ecto.Changeset is not aliased so it gives a function not found error on cast and validate methods.