### PR TITLE
Make defaults to work with plain `use Params.Schema` in to_map function

### DIFF
--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -359,4 +359,17 @@ defmodule ParamsTest do
       }
     }
   end
+
+  defmodule DefaultCountParams do
+    use Params.Schema
+
+    schema do
+      field :count, :integer, default: 1
+    end
+  end
+
+  test "use Params.Schema respects defaults" do
+     changeset = DefaultCountParams.from(%{})
+     assert %{count: 1} = Params.to_map(changeset)
+  end
 end


### PR DESCRIPTION
The catch is that `use Params.Schema %{}` with passed schema, define `@schema` module attribute with fields and their defaults. But when we use plain `use Params.Schema` and define schema with ecto `schema` function there is no extra module attributes such as `@schema` defined. But `to_map` function rely on that missing attribute.

Give a hint If you think that there more proper solution exists.

Related to https://github.com/vic/params/issues/14