### PR TITLE
Fix Dialyzer warnings for Elixir 1.4/OTP 20

### DIFF
--- a/lib/params.ex
+++ b/lib/params.ex
@@ -74,7 +74,7 @@ defmodule Params do
   data.login # => "foo"
   ```
   """
-  @spec data(Changeset.t) :: Struct.t
+  @spec data(Changeset.t) :: struct
   def data(%Changeset{data: data = %{__struct__: module}} = ch) do
     default_embeds = default_embeds_from_schema(module)
 
@@ -195,7 +195,8 @@ defmodule Params do
   end
   defp deep_merge_conflict(_k, _v1, v2), do: v2
 
-  defp defaults(params, acc \\ %{}, path \\ [])
+  defp defaults(params), do: defaults(params, %{}, [])
+  defp defaults(params, acc, path)
   defp defaults([], acc, _path), do: acc
   defp defaults(nil, _acc, _path), do: %{}
   defp defaults([opts | rest], acc, path) when is_list(opts) do

--- a/lib/params/behaviour.ex
+++ b/lib/params/behaviour.ex
@@ -1,8 +1,8 @@
 defmodule Params.Behaviour do
   @moduledoc false
 
-  @callback from(Map.t, Keyword.t) :: Ecto.Changeset.t
-  @callback data(Map.t, Keyword.t) :: Struct.t
-  @callback changeset(Ecto.Changeset.t, Map.t) :: Ecto.Changeset.t
+  @callback from(map, Keyword.t) :: Ecto.Changeset.t
+  @callback data(map, Keyword.t) :: struct
+  @callback changeset(Ecto.Changeset.t, map) :: Ecto.Changeset.t
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,13 +13,14 @@ defmodule Params.Mixfile do
      package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps()]
+     deps: deps(),
+     dialyzer: [plt_add_apps: [:ecto]]]
   end
 
   def description do
   """
   Parameter structure validation and casting with Ecto.Schema.
- """
+  """
   end
 
   def github do
@@ -61,7 +62,8 @@ defmodule Params.Mixfile do
     [
      {:ecto, "~> 2.0"},
      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-     {:earmark, ">= 0.0.0", only: :dev, runtime: false}
+     {:earmark, ">= 0.0.0", only: :dev, runtime: false},
+     {:dialyxir, "~> 0.5", only: :dev, runtime: false},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,10 @@
 %{"bunt": {:hex, :bunt, "0.1.4"},
   "credo": {:hex, :credo, "0.2.5"},
-  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ecto": {:hex, :ecto, "2.1.0", "2e685a5f4f8e02cc48ed9fb8aa31cdd9e8046c20f495f009e5146af0b167b6f5", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
-  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.1.0", "2e685a5f4f8e02cc48ed9fb8aa31cdd9e8046c20f495f009e5146af0b167b6f5", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.5"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"}}


### PR DESCRIPTION
After running Dialyzer on OTP 20, following warning have been emitted:
```
:0: Unknown type 'Elixir.Map':t/0
:0: Unknown type 'Elixir.Struct':t/0
lib/params.ex:198: Function defaults/2 will never be called
```

This commit fixes those warnings and also removes unused auto-generated `defaults/2` function.