### PR TITLE
Fix incorrect `Params.Behaviour.data/2` typespec

### DIFF
--- a/lib/params/behaviour.ex
+++ b/lib/params/behaviour.ex
@@ -2,7 +2,7 @@ defmodule Params.Behaviour do
   @moduledoc false
 
   @callback from(map, Keyword.t) :: Ecto.Changeset.t
-  @callback data(map, Keyword.t) :: struct
+  @callback data(map, Keyword.t) :: {:ok, struct} | {:error, Ecto.Changeset.t}
   @callback changeset(Ecto.Changeset.t, map) :: Ecto.Changeset.t
 
 end


### PR DESCRIPTION
After I updated `params` in our project, I got new Dialyzer warnings:
```
web/controllers/queue_controller.ex:1: The inferred return type of data/2 ({'error',_} | {'ok',#{'__struct__'=>atom(), atom()=>_}}) has nothing in common with #{'__struct__'=>atom(), atom()=>_}, which is the expected return type for the callback of 'Elixir.Params.Behaviour' behaviour
```

The only file that uses `Params.Behaviour` is `Params.Schema`, so I changed callback spec. With this change Dialyzer warnings are gone.