### PR TITLE
Fix Elixir 1.5 warnings

### DIFF
--- a/lib/params.ex
+++ b/lib/params.ex
@@ -108,7 +108,8 @@ defmodule Params do
       nil -> %{}
       schema ->
         schema
-        |> Stream.filter_map(is_embed_default, default_embed)
+        |> Stream.filter(is_embed_default)
+        |> Stream.map(default_embed)
         |> Enum.into(struct(module) |> Map.from_struct)
     end
   end

--- a/lib/params/def.ex
+++ b/lib/params/def.ex
@@ -98,7 +98,9 @@ defmodule Params.Def do
   end
 
   defp field_names(schema, filter) do
-    schema |> Enum.filter_map(filter, &Keyword.get(&1, :name))
+    for field <- schema,
+        apply(filter, [field]),
+        do: Keyword.get(field, :name)
   end
 
   defp schema_fields(schema) do


### PR DESCRIPTION
Elixir 1.5.0 deprecates `Enum.filter_map/3` and `Stream.filter_map/3`.
This commit fixes these warnings.