### PR TITLE
don't remove empty string

### DIFF
--- a/lib/params.ex
+++ b/lib/params.ex
@@ -141,7 +141,7 @@ defmodule Params do
       relation_partition(module, optional(module))
 
     changeset
-    |> Changeset.cast(params, required ++ optional)
+    |> Changeset.cast(params, required ++ optional, [empty_values: [nil]])
     |> Changeset.validate_required(required)
     |> cast_relations(required_relations, [required: true])
     |> cast_relations(optional_relations, [])

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Params.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-     {:ecto, "~> 2.0"},
+     {:ecto, "~> 2.2"},
      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
      {:earmark, ">= 0.0.0", only: :dev, runtime: false},
      {:dialyxir, "~> 0.5", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,12 @@
-%{"bunt": {:hex, :bunt, "0.1.4"},
+%{
+  "bunt": {:hex, :bunt, "0.1.4"},
   "credo": {:hex, :credo, "0.2.5"},
-  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ecto": {:hex, :ecto, "2.1.0", "2e685a5f4f8e02cc48ed9fb8aa31cdd9e8046c20f495f009e5146af0b167b6f5", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto": {:hex, :ecto, "2.2.10", "e7366dc82f48f8dd78fcbf3ab50985ceeb11cb3dc93435147c6e13f2cda0992e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.5"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"}}
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+}


### PR DESCRIPTION
This is a mildly breaking change, but is also what I assumed default behavior would be, curious what others think.

With current cast behaviour, if an empty string is sent as a param, that string gets removed, due to default empty values behaviour https://hexdocs.pm/ecto/Ecto.Changeset.html#module-empty-values

If I want to clear a text field, I typically send a json object of the form 
```
{ field-to-clear: ""}
```

This is getting changed to nil, and I can't clear fields.

I could set default empty string, but there's only one update route, and other actions will send an object of form 
```
{ other-field: 55 }
```
And with default empty string, this unrelated update zeroes out my text field.

This update is all that's necessary to get my narrow use case working, I haven't dug too hard into potential consequences elsewhere.

Requires ecto version bump to pass tests.

Also leaving internet as soon as I post this, so not going to be a good conversationalist for a couple days.