### PR TITLE
Adds compatibility with Ecto 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Params.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-     {:ecto, "~> 2.0"},
+     {:ecto, "~> 2.0 or ~> 3.0"},
      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
      {:earmark, ">= 0.0.0", only: :dev, runtime: false},
      {:dialyxir, "~> 0.5", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,7 @@
-%{"bunt": {:hex, :bunt, "0.1.4"},
-  "credo": {:hex, :credo, "0.2.5"},
-  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], [], "hexpm"},
+%{
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ecto": {:hex, :ecto, "2.1.0", "2e685a5f4f8e02cc48ed9fb8aa31cdd9e8046c20f495f009e5146af0b167b6f5", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto": {:hex, :ecto, "3.0.1", "a26605ee7b243a754e6609d1c23da27bcb22823659b07bf03f9020da92a8e4f4", [:mix], [{:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "fs": {:hex, :fs, "0.9.2"},
-  "mix_test_watch": {:hex, :mix_test_watch, "0.2.5"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"}}
+}

--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -143,13 +143,13 @@ defmodule ParamsTest do
       }) do
 
     def custom(ch, params) do
-      cast(ch, params, ~w(name age))
+      cast(ch, params, ~w(name age)a)
       |> validate_required([:name])
       |> validate_inclusion(:age, 10..20)
     end
 
     def changeset(ch, params) do
-      cast(ch, params, ~w(name age))
+      cast(ch, params, ~w(name age)a)
       |> validate_inclusion(:age, 1..6)
     end
   end
@@ -181,7 +181,7 @@ defmodule ParamsTest do
     use Params.Schema, @schema
 
     def changeset(ch, params) do
-      cast(ch, params, ~w(name))
+      cast(ch, params, ~w(name)a)
       |> validate_required([:name])
       |> cast_embed(:near)
     end


### PR DESCRIPTION
* Can now use Ecto ~> 2.0 or ~> 3.0
* Changed to use atoms as keys in tests to fix warnings
* Clean mix.lock, which also cleaned old dependencies that are no longer
used.

I also tested this in my own project where Params is used.