### PR TITLE
add :logger to extra_applications in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Params.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
This fixes the Elixir 1.11 compiler warnings as mentioned here: https://github.com/vic/params/issues/34