### PR TITLE
Don't add parens to defparams/1

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,6 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [defparams: 1],
+  export: [locals_without_parens: locals_without_parens]
 ]


### PR DESCRIPTION
Configures `defparams/1` to not add parens when being formatted. This falls in line with the examples in the README and general intuition with this type of DSL.