### PR TITLE
Fix warnings

### DIFF
--- a/lib/params.ex
+++ b/lib/params.ex
@@ -124,8 +124,10 @@ defmodule Params do
 
   @doc false
   def optional(module) when is_atom(module) do
-    module.__info__(:attributes) |> Keyword.get(:optional) |> case do
-      nil -> module.__changeset__ |> Map.keys
+    module.__info__(:attributes)
+    |> Keyword.get(:optional)
+    |> case do
+      nil -> module.__changeset__() |> Map.keys()
       x -> x
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule Params.Mixfile do
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      dialyzer: [plt_add_apps: [:ecto]]
+      dialyzer: [plt_add_apps: [:ecto]],
+      xref: [exclude: [Ecto.Changeset]]
     ]
   end
 


### PR DESCRIPTION
Fix the following compile-time warnings in Elixir 1.14.3:

```elixir
==> params
Compiling 4 files (.ex)
warning: Ecto.Changeset.cast/3 defined in application :ecto is used by the current application but the current application does not depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: [Ecto.Changeset]]] to your "def project" in mix.exs

  lib/params.ex:144: Params.changeset/2

warning: Ecto.Changeset.cast_assoc/3 defined in application :ecto is used by the current application but the current application does not depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: [Ecto.Changeset]]] to your "def project" in mix.exs

  lib/params.ex:185: Params.cast_relations/3

warning: Ecto.Changeset.cast_embed/3 defined in application :ecto is used by the current application but the current application does not depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: [Ecto.Changeset]]] to your "def project" in mix.exs

  lib/params.ex:186: Params.cast_relations/3

warning: Ecto.Changeset.change/1 defined in application :ecto is used by the current application but the current application does not depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: [Ecto.Changeset]]] to your "def project" in mix.exs

Invalid call found at 2 locations:
  lib/params.ex:161: Params.change/1
Warning:   lib/params.ex:165: Params.change/1

warning: Ecto.Changeset.validate_required/2 defined in application :ecto is used by the current application but the current application does not depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: [Ecto.Changeset]]] to your "def project" in mix.exs

  lib/params.ex:145: Params.changeset/2

warning: incompatible types:

    map() !~ atom()

in expression:

    # lib/params.ex:130
    module.__changeset__

where "module" was given the type atom() in:

    # lib/params.ex:128
    is_atom(module)

where "module" was given the type map() (due to calling var.field) in:

    # lib/params.ex:130
    module.__changeset__

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/params.ex:130: Params.optional/1
```