### PR TITLE
Fix Elixir 1.20 deprecation and refresh CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     # see https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
@@ -12,9 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - elixir: 1.19.x
+            otp: 28.x
+            lint: true
+          - elixir: 1.19.x
+            otp: 26.x
           - elixir: 1.18.x
             otp: 27.x
-            lint: true
+          - elixir: 1.18.x
+            otp: 25.x
           - elixir: 1.17.x
             otp: 27.x
           - elixir: 1.17.x
@@ -27,22 +33,6 @@ jobs:
             otp: 26.x
           - elixir: 1.15.x
             otp: 24.x
-          - elixir: 1.14.x
-            otp: 25.x
-          - elixir: 1.14.x
-            otp: 23.x
-          - elixir: 1.13.x
-            otp: 24.x
-          - elixir: 1.13.x
-            otp: 22.x
-          - elixir: 1.12.x
-            otp: 24.x
-          - elixir: 1.12.x
-            otp: 22.x
-          - elixir: 1.11.x
-            otp: 23.x
-          - elixir: 1.11.x
-            otp: 21.x
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Params.Mixfile do
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       dialyzer: [plt_add_apps: [:ecto]],
-      xref: [exclude: [Ecto.Changeset]]
+      elixirc_options: [no_warn_undefined: [Ecto.Changeset]]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Params.Mixfile do
     [
       app: :params,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.15",
       name: "Params",
       deps: deps(),
       docs: docs(),


### PR DESCRIPTION
## Changes

- Replace deprecated `xref: [exclude: ...]` with `elixirc_options: [no_warn_undefined: ...]` (deprecated in Elixir 1.20).
- Update CI runner from removed `ubuntu-20.04` to `ubuntu-24.04`.
- Add Elixir 1.19 to the test matrix and move the lint target to it.
- Drop Elixir 1.12, 1.13, 1.14 (no longer in upstream security support).
- Bump minimum supported Elixir version from 1.2 to 1.15 to match CI.

ref: https://github.com/elixir-lang/elixir/blob/v1.20/CHANGELOG.md