### PR TITLE
Harden CI supply chain settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and test
@@ -34,12 +37,12 @@ jobs:
           - elixir: 1.15.x
             otp: 24.x
     steps:
-      - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
-      - run: mix deps.get
+      - run: mix deps.get --check-locked --only test
       - run: mix deps.compile
       - run: mix compile --warnings-as-errors
         if: ${{ matrix.lint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     # see https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
@@ -12,9 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - elixir: 1.19.x
+            otp: 28.x
+            lint: true
+          - elixir: 1.19.x
+            otp: 26.x
           - elixir: 1.18.x
             otp: 27.x
-            lint: true
+          - elixir: 1.18.x
+            otp: 25.x
           - elixir: 1.17.x
             otp: 27.x
           - elixir: 1.17.x
@@ -27,22 +33,6 @@ jobs:
             otp: 26.x
           - elixir: 1.15.x
             otp: 24.x
-          - elixir: 1.14.x
-            otp: 25.x
-          - elixir: 1.14.x
-            otp: 23.x
-          - elixir: 1.13.x
-            otp: 24.x
-          - elixir: 1.13.x
-            otp: 22.x
-          - elixir: 1.12.x
-            otp: 24.x
-          - elixir: 1.12.x
-            otp: 22.x
-          - elixir: 1.11.x
-            otp: 23.x
-          - elixir: 1.11.x
-            otp: 21.x
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
-      - run: mix deps.get --check-locked --only test
+      - run: mix deps.get --check-locked
       - run: mix deps.compile
       - run: mix compile --warnings-as-errors
         if: ${{ matrix.lint }}

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Params.Mixfile do
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       dialyzer: [plt_add_apps: [:ecto]],
-      xref: [exclude: [Ecto.Changeset]]
+      elixirc_options: [no_warn_undefined: [Ecto.Changeset]]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Params.Mixfile do
     [
       app: :params,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.15",
       name: "Params",
       deps: deps(),
       docs: docs(),

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Params.Mixfile do
   defp deps do
     [
       {:ecto, "~> 2.0 or ~> 3.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
## Changes

- Pin `actions/checkout` and `erlef/setup-beam` to commit SHAs.
- Update `actions/checkout` to `v6.0.2`.
- Restrict the workflow `GITHUB_TOKEN` to `contents: read`.
- Fetch only test dependencies with `mix deps.get --check-locked --only test`.
- Tighten the dev-only `ex_doc` requirement to `~> 0.34`.

Stacked on #48. No new workflows or CI jobs are added.